### PR TITLE
Use "$@" to pass parameters to clang correctly

### DIFF
--- a/c++
+++ b/c++
@@ -4,6 +4,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export ICECC_VERSION="x86_64:$DIR/8fa530da0446618be6b7f446e7af7935.tar.gz"
-"$DIR/icecc/icecc" "$DIR/clang_darwin_on_darwin/bin/clang++" -mmacosx-version-min=10.11 $*
-# clang++ -mmacosx-version-min=10.11 $*
+"$DIR/icecc/icecc" "$DIR/clang_darwin_on_darwin/bin/clang++" -mmacosx-version-min=10.11 "$@"
+# clang++ -mmacosx-version-min=10.11 "$@"
 exit $?

--- a/cc
+++ b/cc
@@ -4,5 +4,5 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export ICECC_VERSION="x86_64:$DIR/8fa530da0446618be6b7f446e7af7935.tar.gz"
-"$DIR/icecc/icecc" "$DIR/clang_darwin_on_darwin/bin/clang" -mmacosx-version-min=10.11 $*
+"$DIR/icecc/icecc" "$DIR/clang_darwin_on_darwin/bin/clang" -mmacosx-version-min=10.11 "$@"
 exit $?


### PR DESCRIPTION
After landing bug 1230759, icecc doesn't work well (due to no such file or
directly: '2.2.0-pre') because compiler uses the following parameters.

  ~/icecream/cc '-DPACKAGE_NAME="libsrtp2 2.2.0-pre"' xxx.c

Although ~/icecream/cc uses @* to pass parameter to clang, each parameter
doesn't use double quotation correctly.

So, we should use "$@" to avoid this.